### PR TITLE
Handle 'BYDAY' property when it is provided in weekly rule

### DIFF
--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -306,9 +306,9 @@ def create_recurring_events(start, end, component):
         if freq == 'DAILY':
             delta = timedelta(days=1)
         elif freq == 'WEEKLY':
-            by_day = set(rule.get('BYDAY'))
+            by_day = rule.get('BYDAY')
             if by_day:
-                day_deltas = generate_day_deltas_by_weekday(by_day)
+                day_deltas = generate_day_deltas_by_weekday(set(by_day))
             else:
                 delta = timedelta(days=7)
                 day_deltas = None

--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -306,10 +306,17 @@ def create_recurring_events(start, end, component):
         if freq == 'DAILY':
             delta = timedelta(days=1)
         elif freq == 'WEEKLY':
-            delta = timedelta(days=7)
+            by_day = set(rule.get('BYDAY'))
+            if by_day:
+                day_deltas = generate_day_deltas_by_weekday(by_day)
+            else:
+                delta = timedelta(days=7)
+                day_deltas = None
         else:
             return
         while True:
+            if day_deltas is not None:
+                delta = timedelta(days=day_deltas.get(current.start.weekday()))
             current = current.copy_to(current.start + delta)
             if current.start < limit:
                 unfolded.append(current)
@@ -317,3 +324,36 @@ def create_recurring_events(start, end, component):
                 break
 
     return in_range(unfolded, start, end)
+
+
+def generate_day_deltas_by_weekday(by_day):
+    """
+    Create a dict to determine how many days to add to the current
+    event to get the next event when a WEEKLY rule contains a
+    BYDAY clause.
+
+    The resulting dictionary has the weekday number as keys and the
+    number of days to add to get the next event as values. Weekday
+    numbers are the same as those assigned by the date.weekday()
+    function.
+
+    :param by_day: list or set of two-letter weekday abbreviations
+    :return: dict mapping weekday numbers to day deltas
+    """
+    weekdays = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU']
+
+    selected_weekday_numbers = []
+    day_deltas = []
+    hop_count = 0
+    for weekday_number, weekday_name in enumerate(weekdays):
+        if weekday_name in by_day:
+            selected_weekday_numbers.append(weekday_number)
+            day_deltas.append(hop_count)
+            hop_count = 0
+        hop_count += 1
+
+    # readjust the first deltas to include the remaining deltas
+    first_hop_count = day_deltas[0] + hop_count
+    adjusted_deltas = day_deltas[1:] + [first_hop_count]
+
+    return dict(zip(selected_weekday_numbers, adjusted_deltas))

--- a/test/test_icalparser.py
+++ b/test/test_icalparser.py
@@ -88,3 +88,16 @@ class ICalParserTests(unittest.TestCase):
 
         self.assertEqual(len(filtered), 1, "one event is left")
         self.assertEqual(filtered[0], self.eventA, "event A is left")
+
+    def test_generate_day_deltas_by_weekday(self):
+        by_day = {'MO', 'WE', 'SU'}
+        result = icalevents.icalparser.generate_day_deltas_by_weekday(by_day)
+
+        self.assertEqual(2, result[0], 'Mon to Wed')
+        self.assertEqual(4, result[2], 'Wed to Sun')
+        self.assertEqual(1, result[6], 'Sun to Mon')
+
+        by_day = {'MO'}
+        result = icalevents.icalparser.generate_day_deltas_by_weekday(by_day)
+
+        self.assertEqual(7, result[0], 'Mon to Mon')


### PR DESCRIPTION
This PR  addresses the error highlighted in issue #10.

With this PR, when the `BYDAY` portion is present in a rule, the `days` argument of the `timedelta` constructor is calculated. The calculations are done outside of the loop, so they are only done once and then saved to a variable as a `dict`.

The dict is created as follows. Given a rule like this:
```
RRULE:FREQ=WEEKLY;BYDAY=SU,TU,SA
````
We determine that the event is scheduled on Sundays, Tuesdays, and Saturdays. We conclude the following:
```python
{
   1: 4,  # From Tue to Sat, the next scheduled day, there are 4 days
   5: 1   # From Sat to Sun, the next scheduled day, there is 1 day
   6: 2   # From Sat to Sun, the next scheduled day, there are 2 day
}
```
According to the `datetime.datetime.weekday()` function Monday is 0, Tuesday is 1, Wednesday is 2, and so on. 