### PR TITLE
Fix exdate

### DIFF
--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -6,6 +6,7 @@ from random import randint
 from datetime import datetime, timedelta, date
 
 from icalendar import Calendar
+from icalendar.prop import vDDDLists
 from pytz import utc
 
 
@@ -340,8 +341,11 @@ def extract_exdates(component):
     
     exd_prop = component.get('exdate')
     if exd_prop:
-        for exd_list in exd_prop:
-            dates.extend(exd.dt for exd in exd_list.dts if (exd))
+        if isinstance(exd_prop, list):
+            for exd_list in exd_prop:
+                dates.extend(exd.dt for exd in exd_list.dts)
+        elif isinstance(exd_prop, vDDDLists):
+            dates.extend(exd.dt for exd in exd_prop.dts)
     
     return dates
 

--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -326,8 +326,24 @@ def create_recurring_events(start, end, component):
                 unfolded.append(current)
             else:
                 break
+    
+    reduced_range = in_range(unfolded, start, end)
+    
+    exceptions = extract_exdates(component)
+    reduced_exceptions = [ev for ev in reduced_range if ev.start not in exceptions]
 
-    return in_range(unfolded, start, end)
+    return reduced_exceptions
+
+
+def extract_exdates(component):
+    dates = []
+    
+    exd_prop = component.get('exdate')
+    if exd_prop:
+        for exd_list in exd_prop:
+            dates.extend(exd.dt for exd in exd_list.dts if (exd))
+    
+    return dates
 
 
 def generate_day_deltas_by_weekday(by_day):


### PR DESCRIPTION
This collects all exception dates stored with a component, and then drops all copies of recurring events, whose start is contained in that list.

Not sure if that is the right criterion, but it works for my test case using an ical generated from Google Calendar.