### PR TITLE
Add support for duration

### DIFF
--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -155,7 +155,14 @@ def create_event(component):
     event = Event()
 
     event.start = normalize(component.get('dtstart').dt)
-    event.end = normalize(component.get('dtend').dt)
+    
+    if component.get('dtend'):
+        event.end = normalize(component.get('dtend').dt)
+    elif component.get('duration'):
+        event.end = event.start + component.get('duration').dt
+    else:
+        raise ValueError("Event has neither end, nor duration property.")
+    
     event.summary = str(component.get('summary'))
     event.description = str(component.get('description'))
     event.all_day = type(component.get('dtstart').dt) is date

--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -345,6 +345,12 @@ def create_recurring_events(start, end, component):
 
 
 def extract_exdates(component):
+    """
+    Compile a list of all exception dates stored with a component.
+    
+    :param component: icalendar iCal component
+    :return: exception dates
+    """
     dates = []
 
     exd_prop = component.get('exdate')


### PR DESCRIPTION
If an event has a duration instead of an end, the end is computed as start + duration.

Fix exception reported in #18 .