### PR TITLE
Add a 'recurring' attribute to Event.

### DIFF
--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -40,6 +40,7 @@ class Event:
         self.start = None
         self.end = None
         self.all_day = True
+        self.recurring = False
 
     def time_left(self, time=now()):
         """
@@ -113,6 +114,7 @@ class Event:
             ne.end = (new_start + duration)
 
         ne.all_day = self.all_day
+        ne.recurring = self.recurring
         ne.uid = uid
 
         return ne
@@ -141,7 +143,8 @@ def create_event(component, tz=UTC):
     event.summary = str(component.get('summary'))
     event.description = str(component.get('description'))
     event.all_day = type(component.get('dtstart').dt) is date
-
+    if component.get('rrule'):
+        event.recurring = True
     return event
 
 
@@ -204,7 +207,7 @@ def parse_events(content, start=None, end=None):
     for component in calendar.walk():
         if component.name == "VEVENT":
             e = create_event(component)
-            if component.get('rrule'):
+            if e.recurring:
                 # Unfold recurring events according to their rrule
                 rule = parse_rrule(component, cal_tz)
                 dur = e.end - e.start

--- a/test/test_icalevents.py
+++ b/test/test_icalevents.py
@@ -119,6 +119,25 @@ class ICalEventsTests(unittest.TestCase):
         self.assertEqual(ev.description, "graue Restmülltonne nicht vergessen!")
         self.assertTrue(ev.all_day)
 
+    def test_event_recurring_attribute(self):
+        ical = "test/test_data/basic.ics"
+        start = date(2017, 7, 12)
+        end = date(2017, 7, 13)
+
+        ev = icalevents.events(url=None, file=ical, start=start, end=end)[0]
+        self.assertEqual(ev.recurring, False, "check recurring=False for non recurring event")
+
+        ical = "test/test_data/recurring.ics"
+        start = date(2018, 10, 15)
+        end = date(2018, 11, 15)
+
+        evs = icalevents.events(file=ical, start=start, end=end)
+
+        e1 = evs[1]
+        e2 = evs[2]
+        self.assertEqual(e1.recurring, True, "check recurring=True for recurring event (1)")
+        self.assertEqual(e2.recurring, True, "check recurring=True for recurring event (2)")
+
     def test_events_async_url(self):
         url = "https://raw.githubusercontent.com/irgangla/icalevents/master/test/test_data/basic.ics"
         start = date(2017, 5, 18)


### PR DESCRIPTION
This is a low-impact change. My use-case is I need to distinguish between recurring and non-recurring events. Without this attribute there is no way to tell if an event is a single event or part of a recurring series of events.