### PR TITLE
Fix 'import UTC' error, caused by outdated requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 httplib2
 icalendar
+python-dateutil >= 2.7.0
 pytz
 datetime
 coverage


### PR DESCRIPTION
icalevents requires `dateutil` and uses the `dateutil.tz.UTC` convenience, only added in version 2.7 of `dateutil`.
If used with an older version of `dateutil`, the following exception will occur:
```
>>> from icalevents.icalevents import events
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Python36\lib\site-packages\icalevents\icalevents.py", line 3, in <module>
    from .icalparser import parse_events
  File "C:\Python36\lib\site-packages\icalevents\icalparser.py", line 9, in <module>
    from dateutil.tz import UTC, gettz
ImportError: cannot import name 'UTC'
```

Thanks!