### PR TITLE
Added text-unicode to prevent UnicodeEncodeError in icalparser.

### DIFF
--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -42,6 +42,7 @@ class Event:
         self.end = None
         self.all_day = True
         self.recurring = False
+        self.location = None
 
     def time_left(self, time=now()):
         """
@@ -144,6 +145,7 @@ def create_event(component, tz=UTC):
     event.summary = str(component.get('summary'))
     event.description = str(unidecode(component.get('description')))
     event.all_day = type(component.get('dtstart').dt) is date
+    event.location = str(component.get('location'))
     if component.get('rrule'):
         event.recurring = True
     return event

--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -11,6 +11,7 @@ from dateutil.tz import UTC, gettz
 from icalendar import Calendar
 from icalendar.prop import vDDDLists
 
+from text_unidecode import unidecode
 
 # default query length (one week)
 default_span = timedelta(days=7)
@@ -141,7 +142,7 @@ def create_event(component, tz=UTC):
         event.end = event.start
     
     event.summary = str(component.get('summary'))
-    event.description = str(component.get('description'))
+    event.description = str(unidecode(component.get('description')))
     event.all_day = type(component.get('dtstart').dt) is date
     if component.get('rrule'):
         event.recurring = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytz
 datetime
 coverage
 codecov
+text-unidecode


### PR DESCRIPTION
I received the following error and used text_unidecode to resolve it:
```
>>> es = events(ics_url)
Traceback (most recent call last):
  File "...icalevents/icalparser.py", line 144, in create_event
    event.description = str(component.get('description'))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2026' in position 257: ordinal not in range(128)
```