### PR TITLE
Add 'text-unidecode' to prevent UnicodeEncodeError in icalparser.

### DIFF
--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -11,6 +11,7 @@ from dateutil.tz import UTC, gettz
 from icalendar import Calendar
 from icalendar.prop import vDDDLists
 
+from text_unidecode import unidecode
 
 # default query length (one week)
 default_span = timedelta(days=7)
@@ -140,8 +141,8 @@ def create_event(component, tz=UTC):
     else: # compute implicit end as start + 0
         event.end = event.start
     
-    event.summary = str(component.get('summary'))
-    event.description = str(component.get('description'))
+    event.summary = str(unidecode(component.get('summary')))
+    event.description = str(unidecode(component.get('description')))
     event.all_day = type(component.get('dtstart').dt) is date
     if component.get('rrule'):
         event.recurring = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytz
 datetime
 coverage
 codecov
+text-unidecode


### PR DESCRIPTION
I received the following error and used `text-unidecode` to resolve it:
```
>>> es = events(ics_url)
Traceback (most recent call last):
  File "...icalevents/icalparser.py", line 144, in create_event
    event.description = str(component.get('description'))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2026' in position 257: ordinal not in range(128)
```