### PR TITLE
Fixes bug in icalparser

### DIFF
--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -164,7 +164,7 @@ def normalize(dt, tz=UTC):
         raise ValueError("unknown type %s" % type(dt))
 
     if dt.tzinfo:
-        return dt.astimezone(tz)
+        return dt
     else:
         return dt.replace(tzinfo=tz)
 

--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -164,11 +164,9 @@ def normalize(dt, tz=UTC):
         raise ValueError("unknown type %s" % type(dt))
 
     if dt.tzinfo:
-        dt = dt.astimezone(tz)
+        return dt.astimezone(tz)
     else:
-        dt = dt.replace(tzinfo=tz)
-
-    return dt
+        return dt.replace(tzinfo=tz)
 
 
 def parse_events(content, start=None, end=None):


### PR DESCRIPTION
Fixes issue where the normalize function in icalparser would overwrite tzid from `DTSTART`/`DTEND` with UTC if there isn't a VTIMEZONE in the calendar file. Now properly handles a python object -> icalendar -> icalevents -> python object roundtrip without loosing `tzinfo`.

Fixes #12