### PR TITLE
Fixes wrong default value behaviour in `Event.time_left`

### DIFF
--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -43,12 +43,13 @@ class Event:
         self.recurring = False
         self.location = None
 
-    def time_left(self, time=now()):
+    def time_left(self, time=None):
         """
         timedelta form now to event.
 
         :return: timedelta from now
         """
+        time = time or now()
         return self.start - time
 
     def __lt__(self, other):


### PR DESCRIPTION
In python the default value of an argument gets cached the first
time the function is invoked. Subsequent calls to the function
without specifying the argument will use the same cached default
value again. In this particular case all relative deltas will be
calculated from the now that was cached when the function was
invoked the first time thus leading to a wrong time_left