### PR TITLE
added support for default_span adjustment and additional event components

### DIFF
--- a/icalevents/icalparser.py
+++ b/icalevents/icalparser.py
@@ -12,10 +12,6 @@ from icalendar import Calendar
 from icalendar.prop import vDDDLists
 
 
-# default query length (one week)
-default_span = timedelta(days=7)
-
-
 def now():
     """
     Get current time.
@@ -158,6 +154,23 @@ def create_event(component, tz=UTC):
         event.location = str(component.get('location'))
     except UnicodeEncodeError as e:
         event.location = str(component.get('location').encode('utf-8'))
+
+    if component.get('attendee'):
+        event.attendee = component.get('attendee')
+        if type(event.attendee) is list:
+            temp = []
+            for a in event.attendee:
+                temp.append(a.encode('utf-8').decode('ascii'))
+            event.attendee = temp
+        else:
+            event.attendee = event.attendee.encode('utf-8').decode('ascii')
+
+    if component.get('uid'):
+        event.uid = component.get('uid').encode('utf-8').decode('ascii')
+
+    if component.get('organizer'):
+        event.organizer = component.get('organizer').encode('utf-8').decode('ascii')
+
     return event
 
 
@@ -184,13 +197,14 @@ def normalize(dt, tz=UTC):
     return dt
 
 
-def parse_events(content, start=None, end=None):
+def parse_events(content, start=None, end=None, default_span=timedelta(days=7)):
     """
     Query the events occurring in a given time range.
 
     :param content: iCal URL/file content as String
     :param start: start date for search, default today
     :param end: end date for search
+    :param default_span: default query length (one week)
     :return: events as list
     """
     if not start:

--- a/test/test_icalparser.py
+++ b/test/test_icalparser.py
@@ -24,7 +24,7 @@ class ICalParserTests(unittest.TestCase):
         self.eventB.all_day = False
         self.eventB.summary = "Event B"
         self.eventB.attendee = ["name@example.com", "another@example.com"]
-        self.eventA.organizer = "name@example.com"
+        self.eventB.organizer = "name@example.com"
 
 
         self.dtA = datetime(2018, 6, 21, 12)

--- a/test/test_icalparser.py
+++ b/test/test_icalparser.py
@@ -13,6 +13,9 @@ class ICalParserTests(unittest.TestCase):
         self.eventA.end = datetime(year=2017, month=2, day=3, hour=15, minute=5, tzinfo=UTC)
         self.eventA.all_day = False
         self.eventA.summary = "Event A"
+        self.eventA.attendee = "name@example.com"
+        self.eventA.organizer = "name@example.com"
+
 
         self.eventB = icalevents.icalparser.Event()
         self.eventB.uid = 1234
@@ -20,7 +23,10 @@ class ICalParserTests(unittest.TestCase):
         self.eventB.end = datetime(year=2017, month=2, day=1, hour=16, minute=5, tzinfo=UTC)
         self.eventB.all_day = False
         self.eventB.summary = "Event B"
-        
+        self.eventB.attendee = ["name@example.com", "another@example.com"]
+        self.eventA.organizer = "name@example.com"
+
+
         self.dtA = datetime(2018, 6, 21, 12)
         self.dtB = datetime(2018, 6, 21, 12, tzinfo=gettz('Europe/Berlin'))
 
@@ -88,3 +94,12 @@ class ICalParserTests(unittest.TestCase):
         
         with self.assertRaises(ValueError, msg="type check effective"):
             icalevents.icalparser.normalize(None)
+
+    def test_attendee(self):
+        self.assertIsInstance(self.eventA.attendee, str)
+        self.assertIsInstance(self.eventB.attendee, list)
+    
+    def test_organizer(self):
+        self.assertIsInstance(self.eventA.organizer, str)
+        self.assertIsInstance(self.eventB.organizer, str)
+        


### PR DESCRIPTION
default_span should be user configurable when using parse_events.


Also, additional components are available in the event such as organizer, uid, and attendees. This patch adds support for these components.