### PR TITLE
Disable httplib2 cache when no write permission

### DIFF
--- a/icalevents/icaldownload.py
+++ b/icalevents/icaldownload.py
@@ -5,7 +5,11 @@ from httplib2 import Http
 
 
 # default http connection to use
-default_http = Http('.cache')
+try:
+    default_http = Http('.cache')
+except PermissionError:
+    # Cache disabled if no write permission in working directory
+    default_http = Http()
 
 
 def apple_data_fix(content):


### PR DESCRIPTION
The library cannot be imported from a directory with
no write permissions as httplib2 fails to create the
cache. If there is an error creating `deafult_http`
fall back to having no cache.

Closes #51