### PR TITLE
Initialize default http client for downloader in constructor

### DIFF
--- a/icalevents/icaldownload.py
+++ b/icalevents/icaldownload.py
@@ -4,14 +4,6 @@ Downloads an iCal url or reads an iCal file.
 from httplib2 import Http
 
 
-# default http connection to use
-try:
-    default_http = Http('.cache')
-except PermissionError:
-    # Cache disabled if no write permission in working directory
-    default_http = Http()
-
-
 def apple_data_fix(content):
     """
     Fix Apple tzdata bug.
@@ -38,7 +30,15 @@ class ICalDownload:
     """
     Downloads or reads and decodes iCal sources.
     """
-    def __init__(self, http=default_http, encoding='utf-8'):
+    def __init__(self, http=None, encoding='utf-8'):
+        # default http connection to use
+        if http is None:
+            try:
+                http = Http('.cache')
+            except PermissionError:
+                # Cache disabled if no write permission in working directory
+                http = Http()
+
         self.http = http
         self.encoding = encoding
 

--- a/icalevents/icalevents.py
+++ b/icalevents/icalevents.py
@@ -12,7 +12,15 @@ event_store = {}
 threads = {}
 
 
-def events(url=None, file=None, string_content=None, start=None, end=None, fix_apple=False):
+def events(
+    url=None,
+    file=None,
+    string_content=None,
+    start=None,
+    end=None,
+    fix_apple=False,
+    http=None,
+):
     """
     Get all events form the given iCal URL occurring in the given time range.
 
@@ -27,16 +35,17 @@ def events(url=None, file=None, string_content=None, start=None, end=None, fix_a
     found_events = []
 
     content = None
+    ical_download = ICalDownload(http=http)
 
     if url:
-        content = ICalDownload().data_from_url(url, apple_fix=fix_apple)
+        content = ical_download.data_from_url(url, apple_fix=fix_apple)
 
     if not content and file:
-        content = ICalDownload().data_from_file(file, apple_fix=fix_apple)
+        content = ical_download.data_from_file(file, apple_fix=fix_apple)
 
     if not content and string_content:
-        content = ICalDownload().data_from_string(string_content,
-                                                  apple_fix=fix_apple)
+        content = ical_download.data_from_string(
+            string_content, apple_fix=fix_apple)
 
     found_events += parse_events(content, start=start, end=end)
 


### PR DESCRIPTION
Allowing users to pass a manually created `Http` object to the download class increases flexibility for various circumstances.

The current implementation does not work when used inside an AWS Lambda as the filesystem is read-only and raises an unhandled IOError.

The changes should be fully backwards compatible.