### PR TITLE
Preventing crash when running on AWS Lambda

### DIFF
--- a/icalevents/icaldownload.py
+++ b/icalevents/icaldownload.py
@@ -32,13 +32,16 @@ class ICalDownload:
     Downloads or reads and decodes iCal sources.
     """
     def __init__(self, http=None, encoding='utf-8'):
+        # Get logger
+        logger = logging.getLogger()
+
         # default http connection to use
         if http is None:
             try:
                 http = Http('.cache')
             except (PermissionError, OSError) as e:
                 # Cache disabled if no write permission in working directory
-                logging.warning(("Caching is disabled due to a read-only working directory: {}").format(e))
+                logger.warning(("Caching is disabled due to a read-only working directory: {}").format(e))
                 http = Http()
 
         self.http = http

--- a/icalevents/icaldownload.py
+++ b/icalevents/icaldownload.py
@@ -35,8 +35,9 @@ class ICalDownload:
         if http is None:
             try:
                 http = Http('.cache')
-            except (PermissionError, OSError):
+            except (PermissionError, OSError) as e:
                 # Cache disabled if no write permission in working directory
+                print(("Caching is disabled due to a read-only working directory: {}").format(e))
                 http = Http()
 
         self.http = http

--- a/icalevents/icaldownload.py
+++ b/icalevents/icaldownload.py
@@ -35,7 +35,7 @@ class ICalDownload:
         if http is None:
             try:
                 http = Http('.cache')
-            except PermissionError:
+            except (PermissionError, OSError):
                 # Cache disabled if no write permission in working directory
                 http = Http()
 

--- a/icalevents/icaldownload.py
+++ b/icalevents/icaldownload.py
@@ -2,6 +2,7 @@
 Downloads an iCal url or reads an iCal file.
 """
 from httplib2 import Http
+import logging
 
 
 def apple_data_fix(content):
@@ -37,7 +38,7 @@ class ICalDownload:
                 http = Http('.cache')
             except (PermissionError, OSError) as e:
                 # Cache disabled if no write permission in working directory
-                print(("Caching is disabled due to a read-only working directory: {}").format(e))
+                logging.warning(("Caching is disabled due to a read-only working directory: {}").format(e))
                 http = Http()
 
         self.http = http

--- a/test/test_icaldownload.py
+++ b/test/test_icaldownload.py
@@ -81,17 +81,13 @@ DTSTART:19180331T020000
         os.chmod(os.getcwd(), 0o500)
 
         # Assert log message is being thrown
-        logger = logging.getLogger()
         try:
             with self.assertLogs(level="WARNING") as cm:
                 # Create new ICalDownload instance which will try to create the .cache directory
                 ical_download = icalevents.icaldownload.ICalDownload(http=None)
         finally:
             # Change directory back to old permissions
-            print(oldPerms)
             os.chmod(os.getcwd(), oldPerms)
-
-            print(os.stat(os.getcwd()))
 
             # Delete tmp dir
             os.chdir("..")

--- a/test/test_icaldownload.py
+++ b/test/test_icaldownload.py
@@ -1,5 +1,7 @@
 import unittest
 import icalevents.icaldownload
+import os
+import logging
 
 
 class ICalDownloadTests(unittest.TestCase):
@@ -66,3 +68,18 @@ DTSTART:19180331T020000
         content = icalevents.icaldownload.ICalDownload().data_from_file(file, apple_fix=True)
 
         self.assertEqual(expected, content, "content form iCal file, google format")
+
+    def test_read_only_directory(self):
+        # Save current directory permissions
+        oldPerms = oct(os.stat(os.getcwd()).st_mode)
+        # Set working directory as read-only
+        os.chmod(os.getcwd(), 0o500)
+
+        # Assert log message is being thrown
+        logger = logging.getLogger()
+        with self.assertLogs(level="WARNING") as cm:
+            # Create new ICalDownload instance which will try to create the .cache directory
+            ical_download = icalevents.icaldownload.ICalDownload(http=None)
+
+        # Change directory back to old permissions
+        os.chmod(os.getcwd(), oldPerms)

--- a/test/test_icaldownload.py
+++ b/test/test_icaldownload.py
@@ -70,6 +70,10 @@ DTSTART:19180331T020000
         self.assertEqual(expected, content, "content form iCal file, google format")
 
     def test_read_only_directory(self):
+        # Switch to new directory so we can perform os.chmod()
+        os.mkdir("tmp")
+        os.chdir("tmp")
+
         # Save current directory permissions
         oldPerms = os.stat(os.getcwd()).st_mode
         # Set working directory as read-only
@@ -81,10 +85,14 @@ DTSTART:19180331T020000
             with self.assertLogs(level="WARNING") as cm:
                 # Create new ICalDownload instance which will try to create the .cache directory
                 ical_download = icalevents.icaldownload.ICalDownload(http=None)
-        except:
-            # If the test failed, we have to recover the old directory permissions and let the test fail ultimately
+        finally:
+            # Change directory back to old permissions
+            print(oldPerms)
             os.chmod(os.getcwd(), oldPerms)
-            self.assertTrue(False, "Test run failed. Changed directory permissions back to old permissions.")
 
-        # Change directory back to old permissions
-        os.chmod(os.getcwd(), oldPerms)
+            print(os.stat(os.getcwd()))
+
+            # Delete tmp dir
+            os.chdir("..")
+            os.remove("tmp")
+

--- a/test/test_icaldownload.py
+++ b/test/test_icaldownload.py
@@ -71,15 +71,20 @@ DTSTART:19180331T020000
 
     def test_read_only_directory(self):
         # Save current directory permissions
-        oldPerms = oct(os.stat(os.getcwd()).st_mode)
+        oldPerms = os.stat(os.getcwd()).st_mode
         # Set working directory as read-only
         os.chmod(os.getcwd(), 0o500)
 
         # Assert log message is being thrown
         logger = logging.getLogger()
-        with self.assertLogs(level="WARNING") as cm:
-            # Create new ICalDownload instance which will try to create the .cache directory
-            ical_download = icalevents.icaldownload.ICalDownload(http=None)
+        try:
+            with self.assertLogs(level="WARNING") as cm:
+                # Create new ICalDownload instance which will try to create the .cache directory
+                ical_download = icalevents.icaldownload.ICalDownload(http=None)
+        except:
+            # If the test failed, we have to recover the old directory permissions and let the test fail ultimately
+            os.chmod(os.getcwd(), oldPerms)
+            self.assertTrue(False, "Test run failed. Changed directory permissions back to old permissions.")
 
         # Change directory back to old permissions
         os.chmod(os.getcwd(), oldPerms)

--- a/test/test_icaldownload.py
+++ b/test/test_icaldownload.py
@@ -1,6 +1,7 @@
 import unittest
 import icalevents.icaldownload
 import os
+import shutil
 import logging
 
 
@@ -94,5 +95,5 @@ DTSTART:19180331T020000
 
             # Delete tmp dir
             os.chdir("..")
-            os.remove("tmp")
+            shutil.rmtree("tmp")
 


### PR DESCRIPTION
AWS Lambda functions are run in a readonly directory, which causes an OSError with icalevents as described in #65. Catching this error and calling httplib2 without cache fixes the problem.